### PR TITLE
Fix table titles order

### DIFF
--- a/templates/index.html.j2
+++ b/templates/index.html.j2
@@ -85,8 +85,8 @@ a {
             <th>Time</th>
             <th>Room</th>
             <th>Track</th>
+            <th>Speaker(s)</th>
             <th>Title</th>
-            <th>Persons</th>
             <th>Slides</th>
             <th>WebM video</th>
             <th>MP4 video</th>


### PR DESCRIPTION
The speakers are displayed before the title below.

Also replaced "Persons" by "Speaker(s)".
If I'm not wrong, `Persons` cannot really be used in this context in English.

PS: thank you for the table, nice to see all available videos/slides!